### PR TITLE
Fix whitespace-only message submission bug

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -423,7 +423,7 @@ function MessageInput(props: {
         if (event) {
             event.preventDefault()
         }
-        if (messageInput.length === 0) {
+        if (messageInput.trim().length === 0) {
             return
         }
         props.onSubmit(createMessage('user', messageInput))


### PR DESCRIPTION
Users were able to send messages containing only whitespace characters, which created empty-looking messages in the chat. This fix trims the input before validation, preventing whitespace-only messages from being submitted.

Changes:
- Updated MessageInput submit function to use .trim() before checking if message is empty (App.tsx:426)
