### PR TITLE
Add copy button to code blocks

### DIFF
--- a/src/devtools/App.css
+++ b/src/devtools/App.css
@@ -1,3 +1,52 @@
 .App {
   text-align: center;
 }
+
+.code-block-wrapper {
+  position: relative;
+  margin: 1em 0;
+}
+
+.code-copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 6px 12px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  color: #333;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.2s ease, background-color 0.2s ease;
+  z-index: 1;
+}
+
+.code-block-wrapper:hover .code-copy-btn {
+  opacity: 1;
+}
+
+.code-copy-btn:hover {
+  background-color: rgba(255, 255, 255, 1);
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.code-copy-btn:active {
+  background-color: rgba(240, 240, 240, 1);
+}
+
+.code-copy-btn.copied {
+  background-color: #4caf50;
+  color: white;
+  border-color: #4caf50;
+}
+
+.code-copy-btn svg {
+  width: 14px;
+  height: 14px;
+}

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -39,7 +39,17 @@ const md = new MarkdownIt({
         } else {
             content = md.utils.escapeHtml(str)
         }
-        return `<pre class="hljs" style="max-width: 50vw; overflow: auto"><code>${content}</code></pre>`;
+        const escapedCode = md.utils.escapeHtml(str)
+        return `<div class="code-block-wrapper">
+            <button class="code-copy-btn" data-code="${escapedCode}">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+                Copy
+            </button>
+            <pre class="hljs" style="max-width: 50vw; overflow: auto"><code>${content}</code></pre>
+        </div>`;
     }
 });
 md.use(mdKatex, { blockClass: 'katexmath-block rounded-md p-[10px]', errorColor: ' #cc0000' })
@@ -65,6 +75,7 @@ function _Block(props: Props) {
     const { msg, setMsg } = props
     const [isHovering, setIsHovering] = useState(false)
     const [isEditing, setIsEditing] = useState(false)
+    const contentRef = useRef<HTMLDivElement>(null)
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
@@ -74,6 +85,42 @@ function _Block(props: Props) {
     const handleClose = () => {
         setAnchorEl(null);
     };
+
+    useEffect(() => {
+        if (!contentRef.current) return
+
+        const handleCopyClick = (e: Event) => {
+            const button = e.currentTarget as HTMLButtonElement
+            const code = button.getAttribute('data-code')
+            if (!code) return
+
+            navigator.clipboard.writeText(code).then(() => {
+                const originalText = button.innerHTML
+                button.classList.add('copied')
+                button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>Copied!`
+
+                setTimeout(() => {
+                    button.classList.remove('copied')
+                    button.innerHTML = originalText
+                }, 2000)
+            }).catch(err => {
+                console.error('Failed to copy:', err)
+            })
+        }
+
+        const copyButtons = contentRef.current.querySelectorAll('.code-copy-btn')
+        copyButtons.forEach(button => {
+            button.addEventListener('click', handleCopyClick)
+        })
+
+        return () => {
+            copyButtons.forEach(button => {
+                button.removeEventListener('click', handleCopyClick)
+            })
+        }
+    }, [msg.content])
 
 
     const tips: string[] = []
@@ -151,6 +198,7 @@ function _Block(props: Props) {
                                     />
                                 ) : (
                                     <Box
+                                        ref={contentRef}
                                         sx={{
                                             // bgcolor: "Background",
                                         }}


### PR DESCRIPTION
Added a copy button that appears when hovering over code blocks in chat messages. This improves developer experience by allowing one-click copying of code snippets.

Features:
- Copy button appears on hover over code blocks
- One-click copying to clipboard
- Visual feedback shows "Copied!" with green background for 2 seconds
- Smooth fade-in/fade-out transitions

Changes:
- Modified markdown-it highlight function to wrap code blocks with copy button (Block.tsx:42-52)
- Added useEffect hook to handle clipboard copy functionality (Block.tsx:89-123)
- Added CSS styling for copy button with hover effects (App.css:5-52)
- Added contentRef to Box component for DOM manipulation (Block.tsx:201)