### PR TITLE
Add confirmation dialog for session deletion

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -21,6 +21,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import * as prompts from './prompts'
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import CleanWidnow from './CleanWindow';
+import DeleteSessionDialog from './DeleteSessionDialog';
 import { ThemeSwitcherProvider } from './theme/ThemeSwitcher';
 
 const { useEffect, useState } = React
@@ -89,6 +90,8 @@ function Main() {
     const [configureChatConfig, setConfigureChatConfig] = React.useState<Session | null>(null);
 
     const [sessionClean, setSessionClean] = React.useState<Session | null>(null);
+
+    const [sessionToDelete, setSessionToDelete] = React.useState<Session | null>(null);
 
     const generateName = async (session: Session) => {
         client.replay(
@@ -201,7 +204,7 @@ function Main() {
                                             store.switchCurrentSession(session)
                                             document.getElementById('message-input')?.focus() // better way?
                                         }}
-                                        deleteMe={() => store.deleteChatSession(session)}
+                                        deleteMe={() => setSessionToDelete(session)}
                                         copyMe={() => {
                                             const newSession = createSession(session.name + ' Copyed')
                                             newSession.messages = session.messages
@@ -391,6 +394,17 @@ function Main() {
                         />
                     )
                 }
+                <DeleteSessionDialog
+                    open={sessionToDelete !== null}
+                    session={sessionToDelete}
+                    onConfirm={() => {
+                        if (sessionToDelete) {
+                            store.deleteChatSession(sessionToDelete)
+                        }
+                        setSessionToDelete(null)
+                    }}
+                    onCancel={() => setSessionToDelete(null)}
+                />
                 {
                     store.toasts.map((toast) => (
                         <Snackbar

--- a/src/devtools/DeleteSessionDialog.tsx
+++ b/src/devtools/DeleteSessionDialog.tsx
@@ -1,0 +1,34 @@
+import './App.css';
+import {
+    Button, Dialog, DialogContent, DialogActions, DialogTitle, DialogContentText,
+} from '@mui/material';
+import { Session } from './types'
+
+interface Props {
+    open: boolean
+    session: Session | null
+    onConfirm(): void
+    onCancel(): void
+}
+
+export default function DeleteSessionDialog(props: Props) {
+    if (!props.session) {
+        return null
+    }
+
+    return (
+        <Dialog open={props.open} onClose={props.onCancel}>
+            <DialogTitle>Delete Session</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Are you sure you want to delete the session "{props.session.name}"?
+                    This action cannot be undone and all messages in this session will be permanently lost.
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={props.onCancel}>Cancel</Button>
+                <Button onClick={props.onConfirm} color="error">Delete</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}


### PR DESCRIPTION
Add Confirmation Dialog for Session Deletion
This pull request implements a confirmation dialog to prevent accidental deletion of chat sessions, addressing a critical usability issue where users could permanently lose all session data with a single click. Previously, clicking the delete button on a chat session would immediately and irreversibly delete it without any warning, creating significant risk of accidental data loss. The solution adds a Material-UI confirmation dialog that appears before any session deletion occurs, clearly identifying the session being deleted by name and providing explicit Cancel and Delete options. The implementation adds a new DeleteSessionDialog.tsx component that follows the existing CleanWindow.tsx design pattern for consistency, and modifies App.tsx to manage dialog state through a sessionToDelete React state variable that tracks pending deletions. When users click delete, the dialog opens instead of immediately deleting the session, requiring explicit confirmation via the red Delete button before proceeding, with multiple ways to cancel including a Cancel button, ESC key, or clicking outside the dialog. This change follows all existing codebase patterns, passes linting without introducing new errors, handles edge cases like rapid clicking and null session states, and provides significant user benefits by preventing accidental data loss, clearly communicating consequences, and building user trust through familiar confirmation UX patterns found in modern applications. The implementation is a pure enhancement with no breaking changes, maintaining all existing functionality while adding an essential safety layer to destructive session deletion actions.

Video:
[](https://youtu.be/Tg78TuQOCvw)

Before:
<img width="484" height="217" alt="image" src="https://github.com/user-attachments/assets/f8a004a9-8f7f-4114-91ea-51a09a67209a" />
After:
<img width="1876" height="961" alt="image" src="https://github.com/user-attachments/assets/506e12c7-b35e-4b1a-a369-aaad9d0f796b" />

Fixes #11 