### PR TITLE
Add keyboard shortcut for creating new chat sessions

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -93,6 +93,26 @@ function Main() {
 
     const [sessionToDelete, setSessionToDelete] = React.useState<Session | null>(null);
 
+    // Keyboard shortcut for new chat (Cmd+N / Ctrl+N)
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            // Check for Cmd+N (Mac) or Ctrl+N (Windows/Linux)
+            if (event.key === 'n' && (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
+                event.preventDefault()
+                store.createEmptyChatSession()
+                // Focus the message input after creating new session
+                setTimeout(() => {
+                    document.getElementById('message-input')?.focus()
+                }, 100)
+            }
+        }
+
+        window.addEventListener('keydown', handleKeyDown)
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [store])
+
     const generateName = async (session: Session) => {
         client.replay(
             store.settings.openaiKey,
@@ -227,7 +247,7 @@ function Main() {
                                 New Chat
                             </ListItemText>
                             <Typography variant="body2" color="text.secondary">
-                                {/* ⌘N */}
+                                {/(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent) ? '⌘N' : 'Ctrl+N'}
                             </Typography>
                         </MenuItem>
                         <MenuItem onClick={() => {


### PR DESCRIPTION
before: 
<img width="520" height="329" alt="image" src="https://github.com/user-attachments/assets/558b8f12-84ce-4278-a35e-a39ce70c0704" />
after:
<img width="351" height="176" alt="image" src="https://github.com/user-attachments/assets/86121666-ab00-4c50-b74e-40ff23bfe26a" />

Implement Cmd+N (macOS) and Ctrl+N (Windows/Linux) keyboard shortcut to create new chat sessions, improving productivity for power users who prefer keyboard-driven workflows.

Changes:
- Add global keydown event listener in Main component using useEffect
- Detect Cmd+N on macOS (metaKey) and Ctrl+N on Windows/Linux (ctrlKey)
- Prevent browser default behavior to avoid opening new windows
- Auto-focus message input field after creating new session
- Display platform-specific keyboard hint in UI (⌘N or Ctrl+N)
- Use modern event.key API for keyboard layout independence

The shortcut works from anywhere in the application regardless of focus, providing a seamless experience consistent with modern applications like browsers and text editors. Event listener is properly cleaned up on component unmount to prevent memory leaks.

Fixes #10  

Video:
[https://youtu.be/zbFLESUkF5Q](https://youtu.be/zbFLESUkF5Q)